### PR TITLE
Fix EPEL repository missing, needed for libtidy

### DIFF
--- a/7/Dockerfile
+++ b/7/Dockerfile
@@ -4,8 +4,8 @@ ENV IMAGE_OS=ol-7
 
 COPY rootfs /
 
-RUN yum-config-manager --enable ol7_developer_EPEL ol7_optional_latest && \
+RUN install_packages openssl-libs postgresql-libs tar gzip oracle-epel-release-el7 \
+    yum-config-manager --enable ol7_developer_EPEL ol7_optional_latest && \
     yum upgrade -y && \
-    install_packages openssl-libs postgresql-libs tar gzip
 
-ENV BITNAMI_IMAGE_VERSION=7-r507
+ENV BITNAMI_IMAGE_VERSION=7-r508


### PR DESCRIPTION
Signed-off-by: rafael <rafael@bitnami.com>

Needed to be able to install libtidy